### PR TITLE
Fix cache-control parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ function revalidate(url, callback) {
 ```
 
 
-## Background Revalidation 
+## Background Revalidation
 
 Unless you're able to cache resources forever, use `maxAge` together with `staleWhileRevalidate` to get fault-tolerant, zero-latency cache refreshes.
 
@@ -103,7 +103,7 @@ Creates and returns a new Cache instance.
 
 ### `delete(key)`
 
-Removes the specified item from the cache. 
+Removes the specified item from the cache.
 
 Returns `true` if an item existed and has been removed, or `false` if the item does not exist.
 
@@ -137,15 +137,15 @@ Returns an array with all keys stored in the cache.
 
 Removes all items from the cache.
 
-Outstanding background refreshes will not be cleared to ensure that all queued `revalidate` callbacks are honoured. 
+Outstanding background refreshes will not be cleared to ensure that all queued `revalidate` callbacks are honoured.
 
 ---
 
 ### `set(key, value, [options])`
 
-Inserts a new item with the specified `key` and `value`. 
+Inserts a new item with the specified `key` and `value`.
 
-Returns `true` if the item has been inserted, or `false` otherwise. 
+Returns `true` if the item has been inserted, or `false` otherwise.
 
 ##### Parameters
 
@@ -172,6 +172,7 @@ cache.set('key', 'value', 'no-cache, no-store, must-revalidate'); // false
 
 * `max-age=600, must-revalidate` - Will be cached for 10 minutes and removed afterwards
 * `max-age=600, stale-while-revalidate=86400` - Will be cached for 10 minutes and then refreshed in the background if the item is accessed again within a time window of 1 day
+* `max-age=0` - Will not be cached
 * `no-cache, no-store, must-revalidate` - Will not be cached
 * `private` - Will not be cached
 * `public` - Will be cached using default `maxAge` and `staleWhileRevalidate` options

--- a/lib/stale-lru-cache.js
+++ b/lib/stale-lru-cache.js
@@ -250,7 +250,7 @@ function simpleSize() {
 }
 
 // Ain't pretty but is fast - Parsing 3,000,000 cache-control headers on node v4.2.1:
-// 
+//
 // substr: 1,038 ms (below)
 // split: 2,435 ms (https://github.com/yahoo/storage-lru/blob/master/src/StorageLRU.js#L601)
 // regex: 9,691 ms (https://github.com/roryf/parse-cache-control/blob/master/index.js#L15)
@@ -266,11 +266,11 @@ function parseCacheControl(header) {
 
             pos = header.indexOf('max-age=');
             seconds = (pos !== -1) ? parseInt(header.substr(pos + 8), 10) : NaN;
-            if (seconds) options.maxAge = seconds;
+            if (seconds >= 0) options.maxAge = seconds;
 
             pos = header.indexOf('stale-while-revalidate=');
             seconds = (pos !== -1) ? parseInt(header.substr(pos + 23), 10) : NaN;
-            if (seconds) options.staleWhileRevalidate = seconds;
+            if (seconds >= 0) options.staleWhileRevalidate = seconds;
         }
     }
     return options;

--- a/test/api.js
+++ b/test/api.js
@@ -202,7 +202,7 @@ test("individual item can have its own staleWhileRevalidate", function(t) {
   cache.set("a", "A", { staleWhileRevalidate: 0 / 1000 }) // expires in 20
   cache.set("b", "B") // expires in 40
   cache.set("c", "C", { staleWhileRevalidate: 40 / 1000 }) // expires in 60
-  
+
   t.equal(cache.get("a"), "A")
   t.equal(cache.get("b"), "B")
   t.equal(cache.get("c"), "C")
@@ -257,7 +257,7 @@ test("isStale", function(t) {
   cache.set("a", "A", { maxAge: 10 / 1000 }) // stale in 10
   cache.set("b", "B") // stale in 30
   cache.set("c", "C", { maxAge: 50 / 1000 }) // stale in 50
-  
+
   t.notOk(cache.isStale("a"))
   t.notOk(cache.isStale("b"))
   t.notOk(cache.isStale("c"))
@@ -643,4 +643,12 @@ test("reset does not clear callback queue", function(t) {
   cache.wrap("a", work, done)
   cache.reset()
   t.equal(cache.get('a'), undefined)
+})
+
+test("do not cache with a cache-control header equal to 'max-age=0'", function(t) {
+  var cache = new LRU()
+  t.notOk(cache.set("a", "A", "max-age=0"))
+  t.notOk(cache.has("a"))
+  t.notOk(cache.get("a"))
+  t.end()
 })

--- a/test/api.js
+++ b/test/api.js
@@ -652,3 +652,16 @@ test("do not cache with a cache-control header equal to 'max-age=0'", function(t
   t.notOk(cache.get("a"))
   t.end()
 })
+
+test("do not cache with a cache-control header equal to 'max-age=0' and override instance defaults", function(t) {
+  var cache = new LRU({
+    maxAge: 50 / 1000
+  })
+  t.ok(cache.set("a", "A"))
+  t.ok(cache.has("a"))
+  t.equal(cache.get("a"), "A")
+  t.notOk(cache.set("b", "B", "max-age=0"))
+  t.notOk(cache.has("b"))
+  t.notOk(cache.get("b"))
+  t.end()
+})


### PR DESCRIPTION
Hi @cyberthom, 

I built this pull request to fix the cache-control parser to not cache when the value of "max-age" and  "stale-while-revalidate" are equal to 0.

I'm using the module to cache the result of API calls. For example, the following endpoint `https://api.mercadolibre.com/items/MLA640760266` has a response with a cache-control equal to "max-age=0", so the response should no be cached. But the cache is caching it because the values of `maxAge` and `staleWhileRevalidate` are `NaN`:

```js
Map {
  'get-/items/MLA646293169-' => Node {
  list: Yallist { tail: [Circular], head: [Circular], length: 1 },
  value: 
   Item {
     key: 'get-/items/MLA646293169-',
     value: [Object],
     size: 1,
     now: 1481897490775,
     maxAge: NaN, // Here!
     staleWhileRevalidate: NaN, // Here!
     revalidate: undefined },
  prev: null,
  next: null } }
```

### Test
**Before fix:**
![screen shot 2016-12-16 at 12 32 09 pm](https://cloud.githubusercontent.com/assets/250856/21268330/09a6a08a-c38d-11e6-9f87-0adf928e3d57.png)

**After fix:**
![screen shot 2016-12-16 at 12 37 28 pm](https://cloud.githubusercontent.com/assets/250856/21268332/0c23fc90-c38d-11e6-9076-eda949f306bf.png)

Thanks!